### PR TITLE
Add RO-Crate creation

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -36,7 +36,7 @@ fail-under = 10
 # from-stdin =
 
 # Files or directories to be skipped. They should be base names, not paths.
-ignore = CVS, tests, ro-crate-metadata, create_ro_crate.py, upload_crate.py
+ignore = CVS, tests, ro-crate-metadata
 
 
 # Add files or directories matching the regular expressions patterns to the
@@ -543,5 +543,3 @@ ignored-argument-names = "_.*|^ignored_|^unused_"
 # List of qualified module names which can have objects that can redefine
 # builtins.
 redefining-builtins-modules = ["six.moves", "past.builtins", "future.builtins", "builtins", "io"]
-
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,10 @@ RUN if [ "$BUILD_TEST" = "true" ]; then pip install /app/workflowhub_graph[test]
 COPY Snakefile /app/Snakefile
 COPY config.yaml /app/config.yaml
 
+# Copy files needed for the RO-Crate
+COPY Dockerfile /app/Dockerfile
+COPY README.md /app/README.md
+
 # Set the entry point
 ENV XDG_CACHE_HOME=/app/output/
 ENTRYPOINT ["snakemake", "--snakefile", "Snakefile", "--configfile", "config.yaml", "--cores", "all", "--directory", "/app/output"]

--- a/Snakefile
+++ b/Snakefile
@@ -8,8 +8,9 @@ rule all:
         f"{config['output-dir']}/{config['output-graph']}",
 
         # Enrichment outputs
-        expand("{output_dir}/{strategy}.ttl",
+        expand("{output_dir}/{enrichment_dir}/{strategy}.ttl",
                output_dir=config['output-dir'],
+               enrichment_dir=config['enrichment-output-dir'],
                strategy=config['enrichment-strategies']),
 
         # Metadata
@@ -61,7 +62,7 @@ rule enrich_graph:
     input:
         f"{config['output-dir']}/{config['base-graph']}"
     output:
-        f"{config['output-dir']}/{{strategy}}.ttl"
+        f"{config['output-dir']}/{config['enrichment-output-dir']}/{{strategy}}.ttl"
     shell:
         """
         enrich-graph \
@@ -74,7 +75,7 @@ rule merge_graphs:
     input:
         base=f"{config['output-dir']}/{config['base-graph']}",
         fragments=expand(
-            f"{config['output-dir']}/{{strategy}}.ttl",
+            f"{config['output-dir']}/{config['enrichment-output-dir']}/{{strategy}}.ttl",
             strategy=config['enrichment-strategies']
         )
     output:
@@ -87,8 +88,10 @@ rule merge_graphs:
 
 rule create_ro_crate:
     input:
-        f"{config['output-dir']}/{config['output-graph']}"
+        full_graph = f"{config['output-dir']}/{config['output-graph']}",
+        base_graph = f"{config['output-dir']}/{config['base-graph']}"
     params:
+        enrichments_dir = f"{config['output-dir']}/{config['enrichment-output-dir']}/",
         workflow_file = "/app/Snakefile",
         output_dir = f"{config['output-dir']}/crate"
     output:
@@ -96,7 +99,9 @@ rule create_ro_crate:
     shell:
         """
         create-ro-crate \
-        --input-file {input} \
+        --full-graph {input.full_graph} \
+        --base-graph {input.base_graph} \
+        --enrichments-dir {params.enrichments_dir} \
         --workflow-file {params.workflow_file} \
         --output-dir {params.output_dir}
         """

--- a/Snakefile
+++ b/Snakefile
@@ -16,7 +16,7 @@ rule all:
         #directory(f"{config['paths']['run-metadata']}/"),
 
         # RO-Crate
-        f"{config['output-dir']}/ro-crate-metadata.json"
+        f"{config['output-dir']}/crate/ro-crate-metadata.json"
 
 rule source_ro_crates:
     output:
@@ -89,10 +89,10 @@ rule create_ro_crate:
     input:
         f"{config['output-dir']}/{config['output-graph']}"
     params:
-        workflow_file = "Snakefile",
-        output_dir = f"{config['output-dir']}"
+        workflow_file = "/app/Snakefile",
+        output_dir = f"{config['output-dir']}/crate"
     output:
-        f"{config['output-dir']}/ro-crate-metadata.json"
+        f"{config['output-dir']}/crate/ro-crate-metadata.json"
     shell:
         """
         create-ro-crate \

--- a/Snakefile
+++ b/Snakefile
@@ -15,6 +15,9 @@ rule all:
         # Metadata
         #directory(f"{config['paths']['run-metadata']}/"),
 
+        # RO-Crate
+        f"{config['output-dir']}/ro-crate-metadata.json"
+
 rule source_ro_crates:
     output:
         f"{config['output-dir']}/{config['sourced-list']}"
@@ -81,3 +84,20 @@ rule merge_graphs:
         rdfpipe --input-format=turtle --output-format=turtle \
             {input.base} {input.fragments} > {output.merged}
         """
+
+rule create_ro_crate:
+    input:
+        f"{config['output-dir']}/{config['output-graph']}"
+    params:
+        workflow_file = "Snakefile",
+        output_dir = f"{config['output-dir']}"
+    output:
+        f"{config['output-dir']}/ro-crate-metadata.json"
+    shell:
+        """
+        create-ro-crate \
+        --input-file {input} \
+        --workflow-file {params.workflow_file} \
+        --output-dir {params.output_dir}
+        """
+        

--- a/workflowhub_graph/pyproject.toml
+++ b/workflowhub_graph/pyproject.toml
@@ -16,6 +16,7 @@ authors = [
 dependencies = [
     "arcp >=0.2.1",
     "rdflib >=6.3.2",
+    "rocrate >=0.14.0",
 ]
 
 [project.scripts]
@@ -26,6 +27,7 @@ upload = "workflowhub_graph.upload:main"
 help = "workflowhub_graph.help:main"
 check-outputs = "workflowhub_graph.check_outputs:main"
 enrich-graph = "workflowhub_graph.enrich_graph:main"
+create-ro-crate = "workflowhub_graph.create_ro_crate:main"
 
 [project.optional-dependencies]
 test = [

--- a/workflowhub_graph/workflowhub_graph/create_ro_crate.py
+++ b/workflowhub_graph/workflowhub_graph/create_ro_crate.py
@@ -1,0 +1,158 @@
+import sys
+import uuid
+from datetime import datetime
+
+from rocrate.model import ContextEntity, Person
+from rocrate.rocrate import ROCrate
+
+
+def create_ro_crate(input_file: str, workflow_file: str, output_dir: str) -> None:
+    """
+    Create an RO-Crate metadata file for the given input file and output directory.
+    :param input_file: The input file provided by the Snakemake workflow (e.g., merged data file).
+    :param workflow_file: Reference to the Snakemake workflow.
+    :param output_dir: The output directory to store the RO-Crate metadata file.
+    """
+    crate = ROCrate()
+
+    crate.name = "WorkflowHub Knowledge Graph"
+    crate.description = (
+        "This RO-Crate contains the merged RDF triples from multiple RO-Crates sourced from "
+        "WorkflowHub."
+    )
+
+    # Add authors:
+    auth_1 = crate.add(
+        Person(
+            crate,
+            "https://orcid.org/0000-0003-1193-6632",
+            properties={
+                "givenName": "Alexander",
+                "familyName": "Hambley",
+                "affiliation": "University of Manchester",
+            },
+        )
+    )
+    auth_2 = crate.add(
+        Person(
+            crate,
+            "https://orcid.org/0000-0002-0035-6475",
+            properties={
+                "givenName": "Eli",
+                "familyName": "Chadwick",
+                "affiliation": "University of Manchester",
+            },
+        )
+    )
+    auth_3 = crate.add(
+        Person(
+            crate,
+            "https://orcid.org/0000-0002-4565-9760",
+            properties={
+                "givenName": "Oliver",
+                "familyName": "Woolland",
+                "affiliation": "University of Manchester",
+            },
+        )
+    )
+    auth_4 = crate.add(
+        Person(
+            crate,
+            "https://orcid.org/0000-0001-9842-9718",
+            properties={
+                "givenName": "Stian",
+                "familyName": "Soiland-Reyes",
+                "affiliation": "University of Manchester",
+            },
+        )
+    )
+    auth_5 = crate.add(
+        Person(
+            crate,
+            "https://orcid.org/0000-0001-6353-0808",
+            properties={
+                "givenName": "Volodymyr",
+                "familyName": "Savchenko",
+                "affiliation": "University of Geneva",
+            },
+        )
+    )
+
+    crate.root_dataset["author"] = [auth_1, auth_2, auth_3, auth_4, auth_5]
+
+    # Add dataset and files:
+    crate.add_dataset(
+        "./workflowhub_graph/",
+        properties={
+            "name": "WorkflowHub Graph",
+            "description": "A directory containing modules used by the workflow.",
+        },
+    )
+
+    crate.add_file(
+        "./Dockerfile",
+        properties={
+            "@type": "File",
+            "name": "Dockerfile",
+            "encodingFormat": "text/plain",
+            "description": "The Dockerfile used to build the Docker images for the workflow.",
+            "conformsTo": {"@id": "https://docs.docker.com/reference/dockerfile/"},
+        },
+    )
+
+    created_files = crate.add_file(
+        "./created_files.json",
+        properties={
+            "@type": "File",
+            "name": "created_files.json",
+            "encodingFormat": "application/json",
+            "description": "A JSON file containing the list of files sourced by the workflow.",
+            "conformsTo": {"@id": "https://docs.docker.com/reference/dockerfile/"},
+        },
+    )
+
+    crate.add_file("./poetry.lock")
+    crate.add_file("./README.md")
+
+    # Add data and workflow entities:
+    data_entity = crate.add_file(
+        input_file,
+        properties={
+            "name": "Merged Data File",
+            "description": "This file contains merged RDF triples from multiple RO-Crates sourced from WorkflowHub.",
+            "encodingFormat": "text/turtle",
+        },
+    )
+
+    data_entity["author"] = [auth_1, auth_2, auth_3, auth_4, auth_5]
+    data_entity["isBasedOn"] = created_files
+
+    workflow_entity = crate.add_workflow(
+        source=workflow_file,
+        properties={
+            "name": "Snakemake Workflow",
+            "description": "This is the Snakemake workflow used to generate the merged RDF triples.",
+        },
+        main=True,
+        lang="snakemake",
+    )
+
+    workflow_entity["author"] = [auth_1, auth_2, auth_3, auth_4]
+    workflow_entity["output"] = data_entity
+
+    if "conformsTo" not in crate.root_dataset:
+        crate.root_dataset.append_to(
+            "conformsTo", {"@id": "https://w3id.org/ro/wfrun/workflow/0.5"}
+        )
+
+    # Add license:
+    crate.license = "https://spdx.org/licenses/BSD-2-Clause.html"
+
+    # Writing the RO-Crate metadata:
+    crate.write(output_dir)
+
+
+if __name__ == "__main__":
+    create_ro_crate(
+        input_file=sys.argv[1], workflow_file=sys.argv[2], output_dir=sys.argv[3]
+    )

--- a/workflowhub_graph/workflowhub_graph/create_ro_crate.py
+++ b/workflowhub_graph/workflowhub_graph/create_ro_crate.py
@@ -1,4 +1,6 @@
 import argparse
+import os
+import shutil
 import sys
 import uuid
 from datetime import datetime
@@ -63,7 +65,7 @@ def create_ro_crate(input_file: str, workflow_file: str, output_dir: str) -> Non
 
     # Add dataset and files:
     crate.add_dataset(
-        "./workflowhub_graph/",
+        "/app/workflowhub_graph/",
         properties={
             "name": "WorkflowHub Graph",
             "description": "A directory containing modules used by the workflow.",
@@ -71,7 +73,7 @@ def create_ro_crate(input_file: str, workflow_file: str, output_dir: str) -> Non
     )
 
     crate.add_file(
-        "./Dockerfile",
+        "/app/Dockerfile",
         properties={
             "@type": "File",
             "name": "Dockerfile",
@@ -81,19 +83,7 @@ def create_ro_crate(input_file: str, workflow_file: str, output_dir: str) -> Non
         },
     )
 
-    created_files = crate.add_file(
-        "./created_files.json",
-        properties={
-            "@type": "File",
-            "name": "created_files.json",
-            "encodingFormat": "application/json",
-            "description": "A JSON file containing the list of files sourced by the workflow.",
-            "conformsTo": {"@id": "https://docs.docker.com/reference/dockerfile/"},
-        },
-    )
-
-    crate.add_file("./poetry.lock")
-    crate.add_file("./README.md")
+    crate.add_file("/app/README.md")
 
     # Add data and workflow entities:
     data_entity = crate.add_file(
@@ -106,7 +96,7 @@ def create_ro_crate(input_file: str, workflow_file: str, output_dir: str) -> Non
     )
 
     # data_entity["author"] = [auth_1, auth_2, auth_3, auth_4, auth_5]
-    data_entity["isBasedOn"] = created_files
+    # data_entity["isBasedOn"] = created_files
 
     workflow_entity = crate.add_workflow(
         source=workflow_file,
@@ -118,7 +108,7 @@ def create_ro_crate(input_file: str, workflow_file: str, output_dir: str) -> Non
         lang="snakemake",
     )
 
-    # workflow_entity["author"] = [auth_1, auth_2, auth_3, auth_4]
+    # workflow_entity["author"] = [auth_1, auth_2, auth_3, auth_4] # TODO
     workflow_entity["output"] = data_entity
 
     if "conformsTo" not in crate.root_dataset:
@@ -131,6 +121,12 @@ def create_ro_crate(input_file: str, workflow_file: str, output_dir: str) -> Non
 
     # Writing the RO-Crate metadata:
     crate.write(output_dir)
+
+    # remove package build files from crate
+    shutil.rmtree(os.path.join(output_dir, "workflowhub_graph", "build"))
+    shutil.rmtree(
+        os.path.join(output_dir, "workflowhub_graph", "workflowhub_graph.egg-info")
+    )
 
 
 def main():

--- a/workflowhub_graph/workflowhub_graph/create_ro_crate.py
+++ b/workflowhub_graph/workflowhub_graph/create_ro_crate.py
@@ -8,34 +8,6 @@ from datetime import datetime
 from rocrate.model import ContextEntity, Person
 from rocrate.rocrate import ROCrate
 
-AUTHORS = {
-    "https://orcid.org/0000-0003-1193-6632": {
-        "givenName": "Alexander",
-        "familyName": "Hambley",
-        "affiliation": "University of Manchester",
-    },
-    "https://orcid.org/0000-0002-0035-6475": {
-        "givenName": "Eli",
-        "familyName": "Chadwick",
-        "affiliation": "University of Manchester",
-    },
-    "https://orcid.org/0000-0002-4565-9760": {
-        "givenName": "Oliver",
-        "familyName": "Woolland",
-        "affiliation": "University of Manchester",
-    },
-    "https://orcid.org/0000-0001-9842-9718": {
-        "givenName": "Stian",
-        "familyName": "Soiland-Reyes",
-        "affiliation": "University of Manchester",
-    },
-    "https://orcid.org/0000-0001-6353-0808": {
-        "givenName": "Volodymyr",
-        "familyName": "Savchenko",
-        "affiliation": "University of Geneva",
-    },
-}
-
 
 def create_ro_crate(input_file: str, workflow_file: str, output_dir: str) -> None:
     """
@@ -52,16 +24,95 @@ def create_ro_crate(input_file: str, workflow_file: str, output_dir: str) -> Non
         "WorkflowHub."
     )
 
-    # Add authors:
-    for a in AUTHORS.keys():
-        author = crate.add(
-            Person(
-                crate,
-                a,
-                properties=AUTHORS[a],
-            )
+    org_uniman = crate.add(
+        ContextEntity(
+            crate,
+            "https://ror.org/027m9bs27",
+            properties={"@type": "Organization", "name": "University of Manchester"},
         )
-        crate.root_dataset.append_to("author", author)
+    )
+    org_geneva = crate.add(
+        ContextEntity(
+            crate,
+            "https://ror.org/01swzsf04",
+            properties={"@type": "Organization", "name": "University of Geneva"},
+        )
+    )
+    org_epfl = crate.add(
+        ContextEntity(
+            crate,
+            "https://ror.org/02s376052",
+            properties={
+                "@type": "Organization",
+                "name": "École Polytechnique Fédérale de Lausanne",
+            },
+        )
+    )
+
+    # Add authors:
+    auth_alex = crate.add(
+        Person(
+            crate,
+            "https://orcid.org/0000-0003-1193-6632",
+            properties={
+                "givenName": "Alexander",
+                "familyName": "Hambley",
+            },
+        )
+    )
+    auth_alex["affiliation"] = org_uniman
+    auth_eli = crate.add(
+        Person(
+            crate,
+            "https://orcid.org/0000-0002-0035-6475",
+            properties={
+                "givenName": "Eli",
+                "familyName": "Chadwick",
+            },
+        )
+    )
+    auth_eli["affiliation"] = org_uniman
+    auth_oliver = crate.add(
+        Person(
+            crate,
+            "https://orcid.org/0000-0002-4565-9760",
+            properties={
+                "givenName": "Oliver",
+                "familyName": "Woolland",
+            },
+        )
+    )
+    auth_oliver["affiliation"] = org_uniman
+    auth_stian = crate.add(
+        Person(
+            crate,
+            "https://orcid.org/0000-0001-9842-9718",
+            properties={
+                "givenName": "Stian",
+                "familyName": "Soiland-Reyes",
+            },
+        )
+    )
+    auth_stian["affiliation"] = org_uniman
+    auth_volodymyr = crate.add(
+        Person(
+            crate,
+            "https://orcid.org/0000-0001-6353-0808",
+            properties={
+                "givenName": "Volodymyr",
+                "familyName": "Savchenko",
+            },
+        )
+    )
+    auth_volodymyr["affiliation"] = [org_geneva, org_epfl]
+
+    crate.root_dataset["author"] = [
+        auth_alex,
+        auth_eli,
+        auth_oliver,
+        auth_stian,
+        auth_volodymyr,
+    ]
 
     # Add dataset and files:
     crate.add_dataset(
@@ -95,7 +146,13 @@ def create_ro_crate(input_file: str, workflow_file: str, output_dir: str) -> Non
         },
     )
 
-    # data_entity["author"] = [auth_1, auth_2, auth_3, auth_4, auth_5]
+    data_entity["author"] = [
+        auth_alex,
+        auth_eli,
+        auth_oliver,
+        auth_stian,
+        auth_volodymyr,
+    ]
     # data_entity["isBasedOn"] = created_files
 
     workflow_entity = crate.add_workflow(
@@ -108,7 +165,7 @@ def create_ro_crate(input_file: str, workflow_file: str, output_dir: str) -> Non
         lang="snakemake",
     )
 
-    # workflow_entity["author"] = [auth_1, auth_2, auth_3, auth_4] # TODO
+    workflow_entity["author"] = [auth_alex, auth_eli, auth_oliver, auth_stian]
     workflow_entity["output"] = data_entity
 
     if "conformsTo" not in crate.root_dataset:

--- a/workflowhub_graph/workflowhub_graph/create_ro_crate.py
+++ b/workflowhub_graph/workflowhub_graph/create_ro_crate.py
@@ -9,10 +9,18 @@ from rocrate.model import ContextEntity, Person
 from rocrate.rocrate import ROCrate
 
 
-def create_ro_crate(input_file: str, workflow_file: str, output_dir: str) -> None:
+def create_ro_crate(
+    full_graph_file: str,
+    base_graph_file: str,
+    enrichments_dir: str,
+    workflow_file: str,
+    output_dir: str,
+) -> None:
     """
     Create an RO-Crate metadata file for the given input file and output directory.
-    :param input_file: The input file provided by the Snakemake workflow (e.g., merged data file).
+    :param full_graph_file: The full, enriched knowledge graph.
+    :param base_graph_file: The base knowledge graph prior to enrichment.
+    :param enrichments_dir: Directory containing individual enrichments.
     :param workflow_file: Reference to the Snakemake workflow.
     :param output_dir: The output directory to store the RO-Crate metadata file.
     """
@@ -20,8 +28,10 @@ def create_ro_crate(input_file: str, workflow_file: str, output_dir: str) -> Non
 
     crate.name = "WorkflowHub Knowledge Graph"
     crate.description = (
-        "This RO-Crate contains the merged RDF triples from multiple RO-Crates sourced from "
-        "WorkflowHub."
+        "This RO-Crate contains a knowledge graph built from RO-Crates "
+        "on WorkflowHub, enriched with metadata from additional sources. "
+        "The source code used to create the knowledge graph, including the enrichments, "
+        "is also included."
     )
 
     org_uniman = crate.add(
@@ -118,7 +128,8 @@ def create_ro_crate(input_file: str, workflow_file: str, output_dir: str) -> Non
     crate.add_dataset(
         "/app/workflowhub_graph/",
         properties={
-            "name": "WorkflowHub Graph",
+            "@type": ["Dataset", "SoftwareSourceCode"],
+            "name": "WorkflowHub Graph source code",
             "description": "A directory containing modules used by the workflow.",
         },
     )
@@ -136,24 +147,132 @@ def create_ro_crate(input_file: str, workflow_file: str, output_dir: str) -> Non
 
     crate.add_file("/app/README.md")
 
-    # Add data and workflow entities:
-    data_entity = crate.add_file(
-        input_file,
+    config_file = crate.add_file(
+        "/app/config.yaml",
         properties={
-            "name": "Merged Data File",
-            "description": "This file contains merged RDF triples from multiple RO-Crates sourced from WorkflowHub.",
+            "name": "Workflow configuration",
+            "description": "YAML file containing the configuration of parameters used for the workflow execution.",
+            "encodingFormat": "application/yaml",
+        },
+    )
+
+    # Add data and workflow entities:
+    full_graph_entity = crate.add_file(
+        full_graph_file,
+        properties={
+            "name": "Enriched WorkflowHub Knowledge Graph",
+            "description": "This file contains merged RDF triples from multiple RO-Crates sourced from WorkflowHub, enriched with metadata from related sources.",
             "encodingFormat": "text/turtle",
         },
     )
 
-    data_entity["author"] = [
+    full_graph_entity["author"] = [
         auth_alex,
         auth_eli,
         auth_oliver,
         auth_stian,
         auth_volodymyr,
     ]
-    # data_entity["isBasedOn"] = created_files
+
+    # Add data and workflow entities:
+    enrichment_files = crate.add_dataset(
+        enrichments_dir,
+        properties={
+            "name": "Graph enrichment files",
+            "description": "This directory contains RDF files for each enrichment strategy. These files are combined with the base graph to create the final knowledge graph.",
+            "encodingFormat": "text/turtle",
+        },
+    )
+
+    # Add data and workflow entities:
+    base_graph_entity = crate.add_file(
+        base_graph_file,
+        properties={
+            "name": "Base WorkflowHub knowledge graph",
+            "description": "This file contains merged RDF triples from multiple RO-Crates sourced from WorkflowHub, before enrichment.",
+            "encodingFormat": "text/turtle",
+        },
+    )
+
+    full_graph_entity["isBasedOn"] = [enrichment_files, base_graph_entity]
+
+    # workflow
+    # add parameters
+    config_file_param = crate.add(
+        ContextEntity(
+            crate,
+            "#param-config",
+            properties={
+                "@type": "FormalParameter",
+                "additionalType": "File",
+                "name": "configfile",
+                "description": "A YAML file with parameter configuration for the workflow.",
+                "encodingFormat": "application/yaml",
+                "valueRequired": True,
+            },
+        )
+    )
+    config_file_param["workExample"] = config_file
+    config_file["exampleOfWork"] = config_file_param
+    full_graph_file_param = crate.add(
+        ContextEntity(
+            crate,
+            "#param-full-graph-file",
+            properties={
+                "@type": "FormalParameter",
+                "additionalType": "File",
+                "name": "Full knowledge graph RDF",
+                "description": "An RDF file containing the full knowledge graph.",
+                "encodingFormat": "text/turtle",
+            },
+        )
+    )
+    full_graph_file_param["workExample"] = full_graph_entity
+    full_graph_entity["exampleOfWork"] = full_graph_file_param
+    base_graph_file_param = crate.add(
+        ContextEntity(
+            crate,
+            "#param-base-graph-file",
+            properties={
+                "@type": "FormalParameter",
+                "additionalType": "File",
+                "name": "Base knowledge graph RDF",
+                "description": "An RDF file containing the base knowledge graph prior to enrichment.",
+                "encodingFormat": "text/turtle",
+            },
+        )
+    )
+    base_graph_file_param["workExample"] = base_graph_entity
+    base_graph_entity["exampleOfWork"] = base_graph_file_param
+    enrichment_files_param = crate.add(
+        ContextEntity(
+            crate,
+            "#param-graph-enrichment-files",
+            properties={
+                "@type": "FormalParameter",
+                "additionalType": "Dataset",
+                "name": "Enrichment outputs",
+                "description": "RDF files containing the outputs of each enrichment strategy.",
+                "encodingFormat": "text/turtle",
+            },
+        )
+    )
+    enrichment_files_param["workExample"] = enrichment_files
+    enrichment_files["exampleOfWork"] = enrichment_files_param
+    ro_crate_param = crate.add(
+        ContextEntity(
+            crate,
+            "#param-ro-crate",
+            properties={
+                "@type": "FormalParameter",
+                "additionalType": "Dataset",
+                "name": "RO-Crate output",
+                "description": "An RO-Crate containing the workflow and its outputs.",
+            },
+        )
+    )
+    enrichment_files_param["workExample"] = crate.root_dataset
+    crate.root_dataset["exampleOfWork"] = ro_crate_param
 
     workflow_entity = crate.add_workflow(
         source=workflow_file,
@@ -166,15 +285,49 @@ def create_ro_crate(input_file: str, workflow_file: str, output_dir: str) -> Non
     )
 
     workflow_entity["author"] = [auth_alex, auth_eli, auth_oliver, auth_stian]
-    workflow_entity["output"] = data_entity
+    workflow_entity["input"] = config_file_param
+    workflow_entity["output"] = [
+        full_graph_file_param,
+        base_graph_file_param,
+        enrichment_files_param,
+    ]
 
-    if "conformsTo" not in crate.root_dataset:
-        crate.root_dataset.append_to(
-            "conformsTo", {"@id": "https://w3id.org/ro/wfrun/workflow/0.5"}
+    # workflow execution action
+    execution = crate.add_action(
+        instrument=workflow_entity,
+        identifier=f"#workflow-run-{uuid.uuid4()}",
+        object=config_file,
+        result=[full_graph_entity, base_graph_entity, enrichment_files],
+        properties={"name": "Run of knowledge graph creation workflow"},
+    )
+
+    # add conforms to WRROC
+    wrroc_profile = crate.add(
+        ContextEntity(
+            crate,
+            "https://w3id.org/ro/wfrun/workflow/0.5",
+            properties={
+                "@type": "CreativeWork",
+                "name": "Workflow Run Crate",
+                "version": "0.4",
+            },
         )
+    )
+
+    crate.root_dataset.append_to("conformsTo", wrroc_profile)
 
     # Add license:
-    crate.license = "https://spdx.org/licenses/BSD-2-Clause.html"
+    license = crate.add(
+        ContextEntity(
+            crate,
+            "https://spdx.org/licenses/BSD-2-Clause.html",
+            properties={
+                "@type": "CreativeWork",
+                "name": 'BSD 2-Clause "Simplified" License',
+            },
+        )
+    )
+    crate.license = license
 
     # Writing the RO-Crate metadata:
     crate.write(output_dir)
@@ -189,7 +342,15 @@ def create_ro_crate(input_file: str, workflow_file: str, output_dir: str) -> Non
 def main():
 
     parser = argparse.ArgumentParser(description="Create RO-Crate for the RDF graph.")
-    parser.add_argument("-i", "--input-file", help="The RDF graph file.", required=True)
+    parser.add_argument(
+        "--full-graph", help="The full (enriched) RDF graph file.", required=True
+    )
+    parser.add_argument("--base-graph", help="The base RDF graph file.", required=True)
+    parser.add_argument(
+        "--enrichments-dir",
+        help="Directory containing enrichment files.",
+        required=True,
+    )
     parser.add_argument(
         "-o",
         "--output-dir",
@@ -208,12 +369,18 @@ def main():
     args = parser.parse_args()
 
     # Extract the arguments
-    input_file = args.input_file
+    full_graph_file = args.full_graph
+    base_graph_file = args.base_graph
+    enrichments_dir = args.enrichments_dir
     workflow_file = args.workflow_file
     output_dir = args.output_dir
 
     create_ro_crate(
-        input_file=input_file, workflow_file=workflow_file, output_dir=output_dir
+        full_graph_file=full_graph_file,
+        base_graph_file=base_graph_file,
+        enrichments_dir=enrichments_dir,
+        workflow_file=workflow_file,
+        output_dir=output_dir,
     )
 
 

--- a/workflowhub_graph/workflowhub_graph/create_ro_crate.py
+++ b/workflowhub_graph/workflowhub_graph/create_ro_crate.py
@@ -1,3 +1,6 @@
+# disable pylint check which triggers when setting properties on Entity objects
+# pylint: disable=unsupported-assignment-operation
+
 import argparse
 import os
 import shutil

--- a/workflowhub_graph/workflowhub_graph/create_ro_crate.py
+++ b/workflowhub_graph/workflowhub_graph/create_ro_crate.py
@@ -1,9 +1,38 @@
+import argparse
 import sys
 import uuid
 from datetime import datetime
 
 from rocrate.model import ContextEntity, Person
 from rocrate.rocrate import ROCrate
+
+AUTHORS = {
+    "https://orcid.org/0000-0003-1193-6632": {
+        "givenName": "Alexander",
+        "familyName": "Hambley",
+        "affiliation": "University of Manchester",
+    },
+    "https://orcid.org/0000-0002-0035-6475": {
+        "givenName": "Eli",
+        "familyName": "Chadwick",
+        "affiliation": "University of Manchester",
+    },
+    "https://orcid.org/0000-0002-4565-9760": {
+        "givenName": "Oliver",
+        "familyName": "Woolland",
+        "affiliation": "University of Manchester",
+    },
+    "https://orcid.org/0000-0001-9842-9718": {
+        "givenName": "Stian",
+        "familyName": "Soiland-Reyes",
+        "affiliation": "University of Manchester",
+    },
+    "https://orcid.org/0000-0001-6353-0808": {
+        "givenName": "Volodymyr",
+        "familyName": "Savchenko",
+        "affiliation": "University of Geneva",
+    },
+}
 
 
 def create_ro_crate(input_file: str, workflow_file: str, output_dir: str) -> None:
@@ -22,63 +51,15 @@ def create_ro_crate(input_file: str, workflow_file: str, output_dir: str) -> Non
     )
 
     # Add authors:
-    auth_1 = crate.add(
-        Person(
-            crate,
-            "https://orcid.org/0000-0003-1193-6632",
-            properties={
-                "givenName": "Alexander",
-                "familyName": "Hambley",
-                "affiliation": "University of Manchester",
-            },
+    for a in AUTHORS.keys():
+        author = crate.add(
+            Person(
+                crate,
+                a,
+                properties=AUTHORS[a],
+            )
         )
-    )
-    auth_2 = crate.add(
-        Person(
-            crate,
-            "https://orcid.org/0000-0002-0035-6475",
-            properties={
-                "givenName": "Eli",
-                "familyName": "Chadwick",
-                "affiliation": "University of Manchester",
-            },
-        )
-    )
-    auth_3 = crate.add(
-        Person(
-            crate,
-            "https://orcid.org/0000-0002-4565-9760",
-            properties={
-                "givenName": "Oliver",
-                "familyName": "Woolland",
-                "affiliation": "University of Manchester",
-            },
-        )
-    )
-    auth_4 = crate.add(
-        Person(
-            crate,
-            "https://orcid.org/0000-0001-9842-9718",
-            properties={
-                "givenName": "Stian",
-                "familyName": "Soiland-Reyes",
-                "affiliation": "University of Manchester",
-            },
-        )
-    )
-    auth_5 = crate.add(
-        Person(
-            crate,
-            "https://orcid.org/0000-0001-6353-0808",
-            properties={
-                "givenName": "Volodymyr",
-                "familyName": "Savchenko",
-                "affiliation": "University of Geneva",
-            },
-        )
-    )
-
-    crate.root_dataset["author"] = [auth_1, auth_2, auth_3, auth_4, auth_5]
+        crate.root_dataset.append_to("author", author)
 
     # Add dataset and files:
     crate.add_dataset(
@@ -124,7 +105,7 @@ def create_ro_crate(input_file: str, workflow_file: str, output_dir: str) -> Non
         },
     )
 
-    data_entity["author"] = [auth_1, auth_2, auth_3, auth_4, auth_5]
+    # data_entity["author"] = [auth_1, auth_2, auth_3, auth_4, auth_5]
     data_entity["isBasedOn"] = created_files
 
     workflow_entity = crate.add_workflow(
@@ -137,7 +118,7 @@ def create_ro_crate(input_file: str, workflow_file: str, output_dir: str) -> Non
         lang="snakemake",
     )
 
-    workflow_entity["author"] = [auth_1, auth_2, auth_3, auth_4]
+    # workflow_entity["author"] = [auth_1, auth_2, auth_3, auth_4]
     workflow_entity["output"] = data_entity
 
     if "conformsTo" not in crate.root_dataset:
@@ -152,7 +133,36 @@ def create_ro_crate(input_file: str, workflow_file: str, output_dir: str) -> Non
     crate.write(output_dir)
 
 
-if __name__ == "__main__":
-    create_ro_crate(
-        input_file=sys.argv[1], workflow_file=sys.argv[2], output_dir=sys.argv[3]
+def main():
+
+    parser = argparse.ArgumentParser(description="Create RO-Crate for the RDF graph.")
+    parser.add_argument("-i", "--input-file", help="The RDF graph file.", required=True)
+    parser.add_argument(
+        "-o",
+        "--output-dir",
+        help="The output directory for the RO-Crate.",
+        required=True,
     )
+
+    parser.add_argument(
+        "-w",
+        "--workflow-file",
+        help="The workflow file used to generate the RDF graph.",
+        required=True,
+    )
+
+    # Parse the command line arguments
+    args = parser.parse_args()
+
+    # Extract the arguments
+    input_file = args.input_file
+    workflow_file = args.workflow_file
+    output_dir = args.output_dir
+
+    create_ro_crate(
+        input_file=input_file, workflow_file=workflow_file, output_dir=output_dir
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Builds on @alexhambley's original script to create the RO-Crate for the knowledge graph, with some updates:

- updates to file paths and such because of refactoring
- includes the intermediate outputs (base graph and enrichment files)
- fully complies with WRROC profile (tested with roc-validator) 
    - this required addition of a bunch of FormalParameter entities to describe the workflow in a generalized way
    - each of those entities is linked to the real input/output files used in this particular execution
- follow more best practices (entities for affiliations, license, profiles, etc)